### PR TITLE
main.js: typo fix

### DIFF
--- a/ui/main.js
+++ b/ui/main.js
@@ -66,7 +66,7 @@ const CancelKeyboard = () => {
     for (let i = 0; i < RowsData.length; i++) {
         $(Rows[i]).remove();
     }
-    $.post(`https://rz-keyboard/cancel`)
+    $.post(`https://nh-keyboard/cancel`)
 }
 
 window.addEventListener("message", (evt) => {


### PR DESCRIPTION
Fixed a slight typo that caused keyboard UI to stay stuck on the screen when hitting escape without entering text in field.